### PR TITLE
RECIPES_DETAILS_AND_LIST_RECIPES_SCREEN

### DIFF
--- a/code/lib/utils/side_bar.dart
+++ b/code/lib/utils/side_bar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import '../view/recipes_list_page.dart';
 
 class Sidebar extends StatelessWidget {
   final User? user;
@@ -35,18 +36,23 @@ class Sidebar extends StatelessWidget {
                 ),
                 ListTile(
                   leading: const Icon(Icons.person, color: Colors.blue),
-                  title: const Text('Change Profile Information',
+                  title: const Text('Profile Management',
                       style: TextStyle(color: Colors.teal)),
                   onTap: () {
-                    // Navigating to the profile information screen
+                    // Navigating to the profile management screen
                   },
                 ),
                 ListTile(
-                  leading: const Icon(Icons.favorite, color: Colors.blue),
-                  title: const Text('Favorite Recipes',
+                  leading: const Icon(Icons.restaurant, color: Colors.blue),
+                  title: const Text('Recipes',
                       style: TextStyle(color: Colors.teal)),
                   onTap: () {
-                    // Navigating to the favorite recipes screen
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => const RecipesListPage(),
+                      ),
+                    );
                   },
                 ),
                 ListTile(

--- a/code/lib/view/home_page.dart
+++ b/code/lib/view/home_page.dart
@@ -76,7 +76,7 @@ class _HomePageState extends State<HomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.grey[900],
+      backgroundColor: Colors.grey[800],
       appBar: AppBar(
         centerTitle: true,
         title: const Text(

--- a/code/lib/view/recipes_detail_page.dart
+++ b/code/lib/view/recipes_detail_page.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+
+class RecipesDetailsPage extends StatelessWidget {
+  final String name;
+  final String description;
+
+  const RecipesDetailsPage(
+      {required this.name, required this.description, Key? key})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.grey[800],
+      appBar: AppBar(
+        backgroundColor: Colors.grey[850],
+        title: const Center(
+          child: Text(
+            'Recipe Details',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 24,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+      ),
+      body: Center(
+        child: Column(
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.only(top: 20),
+              child: Card(
+                elevation: 5,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10.0),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: <Widget>[
+                      Text(
+                        name,
+                        style: const TextStyle(
+                          fontSize: 24,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 20),
+                      const Text(
+                        'How Do I Make It?',
+                        style: TextStyle(
+                          fontSize: 20,
+                          fontStyle: FontStyle.italic,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 20),
+            SizedBox(
+              width: double.infinity,
+              height: 300,
+              child: Card(
+                elevation: 5,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10.0),
+                ),
+                child: SingleChildScrollView(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Text(
+                      description,
+                      style: const TextStyle(
+                        fontSize: 16,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            // Add more details here about how to make the recipe
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/code/lib/view/recipes_list_page.dart
+++ b/code/lib/view/recipes_list_page.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import './recipes_detail_page.dart';
+
+class RecipesListPage extends StatelessWidget {
+  const RecipesListPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.grey[800],
+      appBar: AppBar(
+        centerTitle: true,
+        title: const Text(
+          'Recipes',
+          style: TextStyle(color: Colors.white),
+        ),
+        backgroundColor: Colors.grey[850],
+      ),
+      body: ListView(
+        children: <Widget>[
+          Container(
+            margin: const EdgeInsets.only(top: 20.0),
+            child: const RecipeCard(
+              name: 'Recipe 1',
+              description:
+                  "Ingredients: Chicken Yogurt, lemon juice, spices (cumin, coriander, turmeric, paprika, garam masala, chili powder, ginger, garlic) Onion, tomato, cream/coconut milk, oil, salt Instructions: Marinate and grill chicken. Sauté onion, spices, add tomato, and cream/coconut milk. Simmer and add grilled chicken. Garnish and serve with rice or naan. Ingredients: Chicken Yogurt, lemon juice, spices (cumin, coriander, turmeric, paprika, garam masala, chili powder, ginger, garlic) Onion, tomato, cream/coconut milk, oil, salt Instructions: Marinate and grill chicken. Sauté onion, spices, add tomato, and cream/coconut milk. Simmer and add grilled chicken. Garnish and serve with rice or naan",
+            ),
+          ),
+          const RecipeCard(name: 'Recipe 2', description: 'Description 1'),
+        ],
+      ),
+    );
+  }
+}
+
+class RecipeCard extends StatefulWidget {
+  final String name;
+  final String description;
+
+  const RecipeCard({
+    required this.name,
+    required this.description,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  State<RecipeCard> createState() => _RecipeCardState();
+}
+
+class _RecipeCardState extends State<RecipeCard> {
+  bool isStarClicked = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(15.0),
+      ),
+      color: Colors.grey[700],
+      child: ListTile(
+        title: Text(
+          widget.name,
+          style: const TextStyle(
+            fontWeight: FontWeight.bold,
+            color: Colors.white,
+          ),
+        ),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            GestureDetector(
+              child: Icon(
+                isStarClicked ? Icons.star : Icons.star_border,
+                color: isStarClicked ? Colors.teal : null,
+              ),
+              onTap: () {
+                setState(() {
+                  isStarClicked = !isStarClicked;
+                });
+              },
+            ),
+            const SizedBox(width: 12),
+            GestureDetector(
+              child: const Icon(Icons.delete, color: Colors.red),
+              onTap: () {
+                _showDeleteConfirmationDialog(context);
+              },
+            ),
+          ],
+        ),
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => RecipesDetailsPage(
+                name: widget.name,
+                description: widget.description,
+              ),
+            ),
+          );
+        },
+        onLongPress: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => RecipesDetailsPage(
+                name: widget.name,
+                description: widget.description,
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _showDeleteConfirmationDialog(BuildContext context) async {
+    return showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Delete Recipe?'),
+          content: const Text('Are you sure you want to delete this recipe?'),
+          actions: <Widget>[
+            TextButton(
+              child: const Text('No'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+            TextButton(
+              child: const Text('Yes'),
+              onPressed: () {
+                // Add the code here to delete the recipe from Firestore.
+                // You may need to pass some identifier or key to identify which recipe to delete.
+                // After deleting, you can use Navigator.of(context).pop() to close the dialog.
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
* Added the `recipes_details_page` and the `recipies_list_page` dart files to show the basic UI that the two screens will hold with some dummy data.
* Added the required `navigation`  between the two screens, and to come to the recipes screen via the sidebar.
* Added the delete icon and `dialog` to confirm, before deleting a recipe.
* Added a start icon that can be used to mark recipes as `favourites`.

More changes can be done in UI later, this is only done such that other members can use these screens to load the data from Firestore to these screens and can manipulate it.

Screenshots:

List Recipes:
![image](https://github.com/gowtham-padala/COMP_4768_Group_Project/assets/90522185/8b8f572b-a014-43da-b96c-c171d4cb2d76)

Dialog before deletion of recipe:
![image](https://github.com/gowtham-padala/COMP_4768_Group_Project/assets/90522185/3aa292d0-1cb4-44c7-8ee7-61986fe7a831)

Single Recipe view:
![image](https://github.com/gowtham-padala/COMP_4768_Group_Project/assets/90522185/b772918a-4fa3-4bd4-bc29-b4fad35f1308)

Access the screens via Sidebar:
![image](https://github.com/gowtham-padala/COMP_4768_Group_Project/assets/90522185/22552d00-993c-440c-8c65-7db5a09cb483)




